### PR TITLE
Fixed creating vendor/bin before installing tools

### DIFF
--- a/src/Script/Processor.php
+++ b/src/Script/Processor.php
@@ -81,6 +81,11 @@ class Processor
             return false;
         }
 
+        $directory = dirname($filename);
+        if (!file_exists($directory)) {
+            @mkdir($directory, 0777, true);
+        }
+
         file_put_contents($filename, $data);
         chmod($filename, 0755);
 


### PR DESCRIPTION
This fix creates the vendor/bin directory if it is not yet present.
Closes #1