### PR TITLE
Add possibility to set name for downloaded files

### DIFF
--- a/src/Factory/ToolFactory.php
+++ b/src/Factory/ToolFactory.php
@@ -23,6 +23,7 @@ class ToolFactory
             'sign-url' => null,
             'only-dev' => true,
             'force-replace' => false,
+            'rename' => false,
         ];
 
         $parameters = array_merge($defaults, $parameters);
@@ -40,6 +41,10 @@ class ToolFactory
 
         if (false === $parameters['only-dev']) {
             $tool->disableOnlyDev();
+        }
+
+        if (true === $parameters['rename']) {
+            $tool->setNameToToolKey();
         }
 
         return $tool;

--- a/src/Model/Tool.php
+++ b/src/Model/Tool.php
@@ -38,6 +38,11 @@ class Tool
     private $onlyDev = true;
 
     /**
+     * @var bool
+     */
+    private $rename = false;
+
+    /**
      * @param string $name
      * @param string $filename
      * @param string $url
@@ -115,5 +120,21 @@ class Tool
     public function forceReplace()
     {
         return $this->forceReplace;
+    }
+
+    /**
+     * @return void
+     */
+    public function setNameToToolKey()
+    {
+        $this->rename = true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function renameToConfigKey()
+    {
+        return $this->rename;
     }
 }

--- a/src/Script/Processor.php
+++ b/src/Script/Processor.php
@@ -100,6 +100,9 @@ class Processor
         }
 
         $filename = $tool->getFilename();
+        if ($tool->renameToConfigKey()) {
+            $filename = $tool->getName();
+        }
         $composerDir = $this->configuration->getComposerBinDirectory();
         $composerPath = $composerDir . DIRECTORY_SEPARATOR . basename($filename);
 


### PR DESCRIPTION
#### Short description of what this resolves:

This commit allows to rename the downloaded asset to the name that is used as key.

#### Changes proposed in this pull request:

That is triggered by setting the key "rename" to `true` for the element like this:

```json
"tool" : {
    "url" : "https://.../tool-v1.0.0.phar",
    "rename" : true
}
```

This will downlods the file tool-v1.0.0.phar and rename it to the key of the entry, so in this case "tool".

So it can be invoked using `./vendor/bin/tool`

**Fixes**: #
