### PR TITLE
ISSUE-15: (Windows) Missed symlink to phar at bin folder

### DIFF
--- a/src/Script/Helper/Filesystem.php
+++ b/src/Script/Helper/Filesystem.php
@@ -3,6 +3,7 @@
 namespace Tooly\Script\Helper;
 
 use Composer\Util\Filesystem as ComposerFileSystem;
+use Composer\Util\Platform;
 use Composer\Util\Silencer;
 
 /**
@@ -68,7 +69,14 @@ class Filesystem
             return true;
         }
 
-        return $this->filesystem->relativeSymlink($sourceFile, $file);
+        if (Platform::isWindows()) {
+            $sourceFile = $this->filesystem->normalizePath($sourceFile);
+            $file = $this->filesystem->normalizePath($file);
+
+            return Silencer::call('copy', $sourceFile, $file);
+        } else {
+            return $this->filesystem->relativeSymlink($sourceFile, $file);
+        }
     }
 
     /**

--- a/tests/Script/Helper/FilesystemTest.php
+++ b/tests/Script/Helper/FilesystemTest.php
@@ -2,8 +2,7 @@
 
 namespace Tooly\Tests\Script\Helper;
 
-use org\bovigo\vfs\vfsStream;
-use phpmock\phpunit\PHPMock;
+use Composer\Util\Platform;
 use Tooly\Script\Helper\Filesystem;
 
 /**
@@ -42,9 +41,17 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function testCanRelativeSymlinkAFile()
     {
+        if (Platform::isWindows()) {
+            mkdir($this->testDirectory, 0777, true);
+            file_put_contents($this->testFile, '');
+        }
         $symlink = $this->testDirectory . DIRECTORY_SEPARATOR . '/foo/symlink';
 
         $this->assertTrue($this->filesystem->symlinkFile($this->testFile, $symlink));
-        $this->assertNotEquals('/', substr(readlink($symlink), '0', 1));
+        if (Platform::isWindows()) {
+            $this->assertTrue(file_exists($symlink));
+        } else {
+            $this->assertNotEquals('/', substr(readlink($symlink), '0', 1));
+        }
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Fixed Windows OS issue with bin folder

#### Changes proposed in this pull request:
- For Windows environments suggested using copy instead of symlinks

**Version**: 1.x

**Fixes**: 
- [ISSUE-15](https://github.com/tommy-muehle/tooly-composer-script/issues/15)
