### PR TITLE
 Fix checksum of not accessible url using fall back url

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ You can add the requirement with this command:
 This check often fails if you dont has the public key from the tool author 
 in your GPG keychain. 
 
+### fallback-url (optional, default none)
+
+This option is useful if you want to add an extra layer of stability to your daily build processes.
+
+In case the required url is not accessible and a `fallback-url` is set, tooly uses the fallback url to download the phar file. 
+The fallback url can be a link to a specific version, such as x.y.z, or a link to the latest version for this phar.
+
 ### force-replace (optional, default false)
 
 Every time you update or install with composer the phar tools are checked. You are asked if you want to overwrite

--- a/src/Script/Decision/FileAlreadyExistDecision.php
+++ b/src/Script/Decision/FileAlreadyExistDecision.php
@@ -16,7 +16,13 @@ class FileAlreadyExistDecision extends AbstractDecision
      */
     public function canProceed(Tool $tool)
     {
-        if (false === $this->helper->isFileAlreadyExist($tool->getFilename(), $tool->getUrl())) {
+        $url = $tool->getUrl();
+
+        if (false === $this->helper->getDownloader()->isAccessible($url)) {
+            $url = $tool->getFallbackUrl();
+        }
+
+        if (false === $this->helper->isFileAlreadyExist($tool->getFilename(), $url)) {
             return true;
         }
 

--- a/tests/Script/Decision/FileAlreadyExistDecisionTest.php
+++ b/tests/Script/Decision/FileAlreadyExistDecisionTest.php
@@ -2,17 +2,32 @@
 
 namespace Tooly\Tests\Script\Decision;
 
-use Tooly\Factory\ToolFactory;
 use Tooly\Model\Tool;
 use Tooly\Script\Decision\FileAlreadyExistDecision;
+use Tooly\Script\Helper\Downloader;
 
 /**
  * @package Tooly\Tests\Script\Decision
  */
 class FileAlreadyExistDecisionTest extends DecisionTestCase
 {
-    public function testIfFileNotAlreadyExistReturnsTrue()
+    public function testIfFileIsAccessibleAndFileNotAlreadyExistReturnsTrue()
     {
+        $downloader = $this
+            ->getMockBuilder(Downloader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $downloader
+            ->expects($this->once())
+            ->method('isAccessible')
+            ->willReturn(true);
+
+        $this->helper
+            ->expects($this->once())
+            ->method('getDownloader')
+            ->willReturn($downloader);
+
         $this->helper
             ->expects($this->once())
             ->method('isFileAlreadyExist')
@@ -27,8 +42,85 @@ class FileAlreadyExistDecisionTest extends DecisionTestCase
         $this->assertTrue($decision->canProceed($tool));
     }
 
-    public function testIfFileAlreadyExistReturnsFalse()
+    public function testIfFileNotAccessibleAndFileNotAlreadyExistReturnsTrue()
     {
+        $downloader = $this
+            ->getMockBuilder(Downloader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $downloader
+            ->expects($this->once())
+            ->method('isAccessible')
+            ->willReturn(false);
+
+        $this->helper
+            ->expects($this->once())
+            ->method('getDownloader')
+            ->willReturn($downloader);
+
+        $this->helper
+            ->expects($this->once())
+            ->method('isFileAlreadyExist')
+            ->willReturn(false);
+
+        $tool = $this
+            ->getMockBuilder(Tool::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $decision = new FileAlreadyExistDecision($this->configuration, $this->helper);
+        $this->assertTrue($decision->canProceed($tool));
+    }
+
+    public function testIfFileIsAccessibleAndFileAlreadyExistReturnsFalse()
+    {
+        $downloader = $this
+            ->getMockBuilder(Downloader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $downloader
+            ->expects($this->once())
+            ->method('isAccessible')
+            ->willReturn(true);
+
+        $this->helper
+            ->expects($this->once())
+            ->method('getDownloader')
+            ->willReturn($downloader);
+
+        $this->helper
+            ->expects($this->once())
+            ->method('isFileAlreadyExist')
+            ->willReturn(true);
+
+        $tool = $this
+            ->getMockBuilder(Tool::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $decision = new FileAlreadyExistDecision($this->configuration, $this->helper);
+        $this->assertFalse($decision->canProceed($tool));
+    }
+
+    public function testIfFileNotAccessibleAndFileAlreadyExistReturnsFalse()
+    {
+        $downloader = $this
+            ->getMockBuilder(Downloader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $downloader
+            ->expects($this->once())
+            ->method('isAccessible')
+            ->willReturn(false);
+
+        $this->helper
+            ->expects($this->once())
+            ->method('getDownloader')
+            ->willReturn($downloader);
+
         $this->helper
             ->expects($this->once())
             ->method('isFileAlreadyExist')

--- a/tests/Script/Processor/ProcessTest.php
+++ b/tests/Script/Processor/ProcessTest.php
@@ -131,7 +131,7 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $downloader
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(4))
             ->method('isAccessible')
             ->will($this->onConsecutiveCalls(false, true, false));
 
@@ -148,7 +148,7 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
             ->willReturn($filesystem);
 
         $this->helper
-            ->expects($this->exactly(4))
+            ->expects($this->exactly(5))
             ->method('getDownloader')
             ->willReturn($downloader);
 


### PR DESCRIPTION
#### Short description of what this resolves:
This commit addresses a fix for the `FileAlreadyExistDecision.php` for a not accessible url.

#### Changes proposed in this pull request:
In case the provided url is not accessible and the downloaded file already exists, a ErrorException                                                                                 `sha1_file(http://notaccessible.url/version/tool.phar): failed to open stream: Operation timed out` was thrown. This commit fixes this issue by adding an extra check for the accessibility of the url. If the url is not accessible, the fallback url is used for the checksum. 
      
**Version**: 1.4.0

**Fixes**: #
