### PR TITLE
https://github.com/tommy-muehle/tooly-composer-script/issues/21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 bin/*
 !bin/.gitkeep
+.idea

--- a/src/Script/Processor.php
+++ b/src/Script/Processor.php
@@ -101,11 +101,11 @@ class Processor
 
         $filename = $tool->getFilename();
         if ($tool->renameToConfigKey()) {
-            $filename = $tool->getName();
+          $filename = dirname($filename) . DIRECTORY_SEPARATOR . $tool->getName();
         }
         $composerDir = $this->configuration->getComposerBinDirectory();
         $composerPath = $composerDir . DIRECTORY_SEPARATOR . basename($filename);
-
+        $filename = str_replace('.phar', '', $filename) . '.phar';
         if (Platform::isWindows()) {
             $this->helper->getFilesystem()->copyFile($filename, $composerPath);
         } else {


### PR DESCRIPTION
#### Short description of what this resolves:
Resolves an issue with not coping the Phar file because the path is not absolute.

#### Changes proposed in this pull request:

- give the phar an absolute path
-
-

**Version**: 1.x

**Fixes**: #21 
